### PR TITLE
Fix: use only one seed when planting

### DIFF
--- a/maidroid_core/cores/farming.lua
+++ b/maidroid_core/cores/farming.lua
@@ -329,9 +329,10 @@ plant = function(self, dtime)
 			}
 
                         local plantname = get_plantname(itemname)
-			farming.place_seed(stack, minetest.get_player_by_name(self.owner_name), pointed_thing, plantname)
 
-			stack:take_item(1)
+			
+			stack = farming.place_seed(stack, minetest.get_player_by_name(self.owner_name), pointed_thing, plantname)
+
 			self:set_wield_item_stack(stack)
 		end
 		to_walk_randomly(self)


### PR DESCRIPTION
The whole wielded seed stack is used by the maidroid.
So the maidroid never collect seed for wheat as the stack decreases to 0 immediately.
Not so ennoying for wheat, but for let's say cucumber were the seed is also the "cookable/eatable" item, you maidroid will never collect anything